### PR TITLE
p2/issue-<34>-replace-set-constructor-with-literal-oauth-migration

### DIFF
--- a/src/pretix/api/migrations/0001_initial.py
+++ b/src/pretix/api/migrations/0001_initial.py
@@ -123,6 +123,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='oauthrefreshtoken',
-            unique_together=set([('token', 'revoked')]),
+            unique_together={('token', 'revoked')},
         ),
     ]


### PR DESCRIPTION
Closes #34

## Summary
Replaced `set([...])` constructor syntax with Python's native set literal 
syntax `{...}` on L126 of the OAuth migration file. The constructor 
unnecessarily creates an intermediate list before converting to a set. 
Addresses SonarQube rule python:S7496.

## Changes
- L126: `unique_together=set([('token', 'revoked')])` 
       → `unique_together={('token', 'revoked')}`
- No other lines or files modified

## Verification
- Ran `python manage.py migrate` — completes without errors
- Ran full test suite — all tests pass
- Confirmed migration state unaffected via `showmigrations`

## Evidence
- Before: `set([('token', 'revoked')])` — unnecessary constructor wrapping
- After: `{('token', 'revoked')}` — clean Python set literal
- Zero behavior change — identical migration output
- SonarQube rule python:S7496 (Minor) resolved