### PR TITLE
p2/issue-<32>-chain-run-instructions-dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ RUN pip3 install -U \
     PRETIX_DOCKER_BUILD=TRUE pip3 install \
         -e ".[memcached]" \
         gunicorn django-extensions ipython && \
-    rm -rf ~/.cache/pip
+    rm -rf ~/.cache/pip && \
 
-RUN chmod +x /usr/local/bin/pretix && \
+    chmod +x /usr/local/bin/pretix && \
     rm /etc/nginx/sites-enabled/default && \
     cd /pretix/src && \
     rm -f pretix.cfg &&  \


### PR DESCRIPTION
Closes #<32>

## Summary
Merged two consecutive `RUN` instructions (L53–L68) into a single chained 
`RUN` using `&&` and `\` in the production Dockerfile. Each separate `RUN` 
creates a new image layer — combining them reduces the final image size and 
improves build efficiency. Addresses SonarQube rule docker:S7031.

## Changes
- Merged the second `RUN` block (chmod, nginx cleanup, pretix.cfg removal, 
  data dir setup, chown) into the first `RUN` block via `&&`
- Removed the now-redundant second `RUN` instruction entirely
- No commands added, removed, or reordered — only structural chaining

## Verification
- Ran `docker build` — completes without errors
- Compared image size before and after — equal or smaller
- Started container and confirmed application boots correctly
- CI/CD pipeline passes end-to-end

## Evidence
- Before: 2 separate `RUN` instructions creating 2 layers (L53–L68)
- After: single chained `RUN` instruction creating 1 layer
- No behavior change — identical commands, identical build output
- SonarQube rule docker:S7031 (Minor) resolved