### PR TITLE
630:P3 #76 Refactor set_defaults() with Strategy pattern

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -705,17 +705,25 @@ class Event(EventMixin, LoggedModel):
         This will be called after event creation, but only if the event was not created by copying an existing one.
         This way, we can use this to introduce new default settings to pretix that do not affect existing events.
         """
-        self.settings.invoice_renderer = 'modern1'
-        self.settings.invoice_include_expire_date = True
-        self.settings.invoice_renderer_highlight_order_code = True
-        self.settings.ticketoutput_pdf__enabled = True
-        self.settings.ticketoutput_passbook__enabled = True
-        self.settings.event_list_type = 'calendar'
-        self.settings.invoice_email_attachment = True
-        self.settings.name_scheme = 'given_family'
-        self.settings.payment_banktransfer_invoice_immediately = True
-        self.settings.low_availability_percentage = 10
-
+        def set_defaults(self):
+    """
+    This will be called after event creation, but only if the event was not created by copying an existing o
+    This way, we can use this to introduce new default settings to pretix that do not affect existing events
+    """
+    from pretix.base.models.event_defaults_strategies import (
+        InvoiceDefaultsStrategy,
+        TicketOutputDefaultsStrategy,
+        DisplayDefaultsStrategy,
+        PaymentDefaultsStrategy,
+    )
+    strategies = [
+        InvoiceDefaultsStrategy(),
+        TicketOutputDefaultsStrategy(),
+        DisplayDefaultsStrategy(),
+        PaymentDefaultsStrategy(),
+    ]
+    for strategy in strategies:
+        strategy.apply(self)
     @property
     def social_image(self):
         from pretix.multidomain.urlreverse import build_absolute_uri

--- a/src/pretix/base/models/event_defaults_strategies.py
+++ b/src/pretix/base/models/event_defaults_strategies.py
@@ -1,0 +1,29 @@
+class EventDefaultsStrategy:
+    def apply(self, event):
+        raise NotImplementedError
+
+
+class InvoiceDefaultsStrategy(EventDefaultsStrategy):
+    def apply(self, event):
+        event.settings.invoice_renderer = 'modern1'
+        event.settings.invoice_include_expire_date = True
+        event.settings.invoice_renderer_highlight_order_code = True
+        event.settings.invoice_email_attachment = True
+
+
+class TicketOutputDefaultsStrategy(EventDefaultsStrategy):
+    def apply(self, event):
+        event.settings.ticketoutput_pdf__enabled = True
+        event.settings.ticketoutput_passbook__enabled = True
+
+
+class DisplayDefaultsStrategy(EventDefaultsStrategy):
+    def apply(self, event):
+        event.settings.event_list_type = 'calendar'
+        event.settings.name_scheme = 'given_family'
+        event.settings.low_availability_percentage = 10
+
+
+class PaymentDefaultsStrategy(EventDefaultsStrategy):
+    def apply(self, event):
+        event.settings.payment_banktransfer_invoice_immediately = True

--- a/src/tests/base/test_event_defaults_strategies.py
+++ b/src/tests/base/test_event_defaults_strategies.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+from pretix.base.models.event_defaults_strategies import (
+    InvoiceDefaultsStrategy,
+    TicketOutputDefaultsStrategy,
+    DisplayDefaultsStrategy,
+)
+
+def test_invoice_defaults():
+    event = MagicMock()
+    InvoiceDefaultsStrategy().apply(event)
+    event.settings.__setattr__.assert_any_call('invoice_renderer', 'modern1')
+
+def test_ticket_defaults():
+    event = MagicMock()
+    TicketOutputDefaultsStrategy().apply(event)
+    event.settings.__setattr__.assert_any_call('ticketoutput_pdf__enabled', True)
+
+def test_display_defaults():
+    event = MagicMock()
+    DisplayDefaultsStrategy().apply(event)
+    event.settings.__setattr__.assert_any_call('name_scheme', 'given_family')


### PR DESCRIPTION
## Problem
The set_defaults() method in the Event model was a God Object anti-pattern.
It was directly setting over 10 unrelated default settings all in one place —
invoice rendering, ticket output, payment behavior, and display preferences 
were all mixed together in a single method on the core Event model.

## What I changed
Applied the Strategy pattern to fix this:
- Created a new file `event_defaults_strategies.py` with 4 strategy classes:
  - InvoiceDefaultsStrategy — handles invoice-related defaults
  - TicketOutputDefaultsStrategy — handles ticket output defaults
  - DisplayDefaultsStrategy — handles display/UI defaults
  - PaymentDefaultsStrategy — handles payment defaults
- Updated set_defaults() in event.py to loop over these strategy classes
  instead of setting everything directly
- The Event model no longer knows the internal setting keys of each subsystem

## Pattern used
Strategy (Behavioral)

## Verification
- set_defaults() no longer contains any direct self.settings assignments
- All 4 strategy classes are independently testable
- Added unit tests in test_event_defaults_strategies.py
- No default values were changed — purely structural refactor

Closes #76